### PR TITLE
feat: supporting bumps within monorepos

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ jobs:
 
 ## ⚡ Inputs
 
+### 🔶 `cwd`
+
+Path location of the package to bump. Useful for monorepos.
+
+> Default value: **.**
+
 ### 🔶 `major-keywords`
 
 Commits messages starting with these keywords will trigger a major bump. Commas may be used to specify more than one keyword
@@ -277,3 +283,47 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
+
+You can also get the new version using `new-version` output:
+
+```yaml
+- name: Display action output
+  run: |
+    echo "New version: ${{ steps.bumping-version.outputs.new-version }}"
+```
+
+### 🔶 Monorepos
+
+You can use the input `cwd` to perform a bump for a monorepo app or package. The following job would bump the package.json file located at `./libs/my-package/package.json`:
+
+```yaml
+name: ⚡ Package version bump
+on: [push]
+jobs:
+  bump:
+    name: 🆕 Version bump
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: ⬇️ Checkout repo
+      uses: actions/checkout@v4
+
+    [...]
+
+    - name: ⏫ Bumping version
+      uses: jpb06/bump-package@latest
+      with:
+        cwd: ./libs/my-package
+```
+
+#### The pushed version tag will look like this: `<package_name>@v<version>`.
+
+Example:
+
+> `my-package@v2.3.0`
+
+#### The bump commit will have the following message: `chore(<package_name>): bump version to <version>`.
+
+Eexample:
+
+> `chore(my-package): bump version to v2.3.0`

--- a/README.md
+++ b/README.md
@@ -316,13 +316,13 @@ jobs:
         cwd: ./libs/my-package
 ```
 
-#### The pushed version tag will look like this: `<package_name>@v<version>`.
+#### The pushed version tag will look like this: `<package_name>@v<version>`
 
 Example:
 
 > `my-package@v2.3.0`
 
-#### The bump commit will have the following message: `chore(<package_name>): bump version to <version>`.
+#### The bump commit will have the following message: `chore(<package_name>): bump version to <version>`
 
 Eexample:
 

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,9 @@ name: 'Bump package version'
 description: 'Bumping package version depending on keywords present in the commit message'
 
 inputs:
+  cwd:
+    description: 'Path location of the package to bump.'
+    default: '.'
   major-keywords:
     description: 'Keywords triggering a major bump, separated by commas if more than one.'
     default: '[Major]:'

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -7,3 +7,4 @@ export * from './not-running-on-default-branch.error.js';
 export * from './unknown-current-branch.error.js';
 export * from './unknown-default-branch.error.js';
 export * from './package-json-version-fetching.error.js';
+export * from './package-json-name-fetching.error.js';

--- a/src/errors/package-json-name-fetching.error.ts
+++ b/src/errors/package-json-name-fetching.error.ts
@@ -1,0 +1,8 @@
+import { TaggedError } from 'effect/Data';
+
+export class PackageJsonNameFetchingError extends TaggedError(
+  'package-json-name-fetching-failure',
+)<{
+  cause?: unknown;
+  message?: string;
+}> {}

--- a/src/git/get-git-bump-data.ts
+++ b/src/git/get-git-bump-data.ts
@@ -1,0 +1,30 @@
+import path from 'node:path';
+import { Effect, pipe } from 'effect';
+
+import { PackageJsonNameFetchingError } from '../errors/index.js';
+import { readJsonEffect } from '../fs/fs.effects.js';
+import type { PackageJson } from '../types/index.js';
+
+export const getGitBumpData = (cwd: string) =>
+  pipe(
+    Effect.gen(function* () {
+      const packageData = yield* readJsonEffect<PackageJson>(
+        path.join(cwd, 'package.json'),
+      );
+
+      const tagPrefix = `${packageData.name}@v`;
+      const message = `chore(${packageData.name}): bump version to %s`;
+
+      return {
+        tagPrefix,
+        message,
+      };
+    }),
+    Effect.catchAll(
+      (e) =>
+        new PackageJsonNameFetchingError({
+          cause: e,
+        }),
+    ),
+    Effect.withSpan('get-git-bump-data', { attributes: { cwd } }),
+  );

--- a/src/github-actions/exec/set-version.ts
+++ b/src/github-actions/exec/set-version.ts
@@ -2,38 +2,9 @@ import { getInput } from '@actions/core';
 import { exec } from '@actions/exec';
 import { Effect, pipe } from 'effect';
 
-import path from 'node:path';
-import {
-  GithubActionsExecError,
-  PackageJsonNameFetchingError,
-} from '../../errors/index.js';
-import { readJsonEffect } from '../../fs/fs.effects.js';
+import { GithubActionsExecError } from '../../errors/index.js';
+import { getGitBumpData } from '../../git/get-git-bump-data.js';
 import type { BumpType } from '../../semver/get-bump-type.js';
-import type { PackageJson } from '../../types/index.js';
-
-const getGitBumpData = (cwd: string) =>
-  pipe(
-    Effect.gen(function* () {
-      const packageData = yield* readJsonEffect<PackageJson>(
-        path.join(cwd, 'package.json'),
-      );
-
-      const tagPrefix = `${packageData.name}@v`;
-      const message = `chore(${packageData.name}): bump version to %s`;
-
-      return {
-        tagPrefix,
-        message,
-      };
-    }),
-    Effect.catchAll(
-      (e) =>
-        new PackageJsonNameFetchingError({
-          cause: e,
-        }),
-    ),
-    Effect.withSpan('get-git-bump-data', { attributes: { cwd } }),
-  );
 
 export const setVersion = (bumpType: BumpType) =>
   pipe(

--- a/src/github-actions/exec/set-version.ts
+++ b/src/github-actions/exec/set-version.ts
@@ -1,15 +1,65 @@
+import { getInput } from '@actions/core';
 import { exec } from '@actions/exec';
 import { Effect, pipe } from 'effect';
 
-import { GithubActionsExecError } from '../../errors/index.js';
+import path from 'node:path';
+import {
+  GithubActionsExecError,
+  PackageJsonNameFetchingError,
+} from '../../errors/index.js';
+import { readJsonEffect } from '../../fs/fs.effects.js';
 import type { BumpType } from '../../semver/get-bump-type.js';
+import type { PackageJson } from '../../types/index.js';
+
+const getGitBumpData = (cwd: string) =>
+  pipe(
+    Effect.gen(function* () {
+      const packageData = yield* readJsonEffect<PackageJson>(
+        path.join(cwd, 'package.json'),
+      );
+
+      const tagPrefix = `${packageData.name}@v`;
+      const message = `chore(${packageData.name}): bump version to %s`;
+
+      return {
+        tagPrefix,
+        message,
+      };
+    }),
+    Effect.catchAll(
+      (e) =>
+        new PackageJsonNameFetchingError({
+          cause: e,
+        }),
+    ),
+    Effect.withSpan('get-git-bump-data', { attributes: { cwd } }),
+  );
 
 export const setVersion = (bumpType: BumpType) =>
   pipe(
-    Effect.tryPromise({
-      try: () => exec('npm version', [bumpType, '--force']),
-      catch: (e) =>
-        new GithubActionsExecError({ message: (e as Error).message }),
+    Effect.gen(function* () {
+      const cwd = getInput('cwd');
+
+      const { message, tagPrefix } = yield* getGitBumpData(cwd);
+
+      yield* Effect.tryPromise({
+        try: () =>
+          exec(
+            'npm version',
+            [
+              bumpType,
+              '--force',
+              `--tag-version-prefix=${tagPrefix}`,
+              '--m',
+              message,
+            ],
+            {
+              cwd,
+            },
+          ),
+        catch: (e) =>
+          new GithubActionsExecError({ message: (e as Error).message }),
+      });
     }),
     Effect.withSpan('set-version', { attributes: { bumpType } }),
   );

--- a/src/github/event/maybe-debug-event.ts
+++ b/src/github/event/maybe-debug-event.ts
@@ -1,7 +1,7 @@
 import { getInput, info } from '@actions/core';
 import { Effect, pipe } from 'effect';
 
-import type { GithubEvent } from '../../types/github.types.js';
+import type { GithubEvent } from '../../types/index.js';
 
 export const maybeDebugEvent = (event?: GithubEvent) =>
   pipe(

--- a/src/github/event/read-github-event.ts
+++ b/src/github/event/read-github-event.ts
@@ -4,7 +4,7 @@ import { env } from 'node:process';
 import { Effect, pipe } from 'effect';
 
 import { NoGithubEventError } from '../../errors/index.js';
-import type { GithubEvent } from '../../types/github.types.js';
+import type { GithubEvent } from '../../types/index.js';
 
 export const readGithubEvent = pipe(
   pipe(

--- a/src/github/extract-commits-messages.ts
+++ b/src/github/extract-commits-messages.ts
@@ -1,7 +1,7 @@
 import { Effect, pipe } from 'effect';
 
 import { CommitMessagesExtractionError } from '../errors/index.js';
-import type { GithubEvent } from '../types/github.types.js';
+import type { GithubEvent } from '../types/index.js';
 
 const extractSquashCommitMessage = (message: string) =>
   message

--- a/src/github/fail-if-no-default-branch.ts
+++ b/src/github/fail-if-no-default-branch.ts
@@ -1,7 +1,7 @@
 import { Effect, pipe } from 'effect';
 
 import { UnknownDefaultBranchError } from '../errors/index.js';
-import type { GithubEvent } from '../types/github.types.js';
+import type { GithubEvent } from '../types/index.js';
 
 export const failIfNoDefaultBranch = (event?: GithubEvent) =>
   pipe(

--- a/src/github/fail-if-not-running-on-default-branch.ts
+++ b/src/github/fail-if-not-running-on-default-branch.ts
@@ -1,7 +1,7 @@
 import { Effect, pipe } from 'effect';
 
 import { NotRunningOnDefaultBranchError } from '../errors/index.js';
-import type { GithubEvent } from '../types/github.types.js';
+import type { GithubEvent } from '../types/index.js';
 
 import { getCurrentBranch } from './get-current-branch.js';
 

--- a/src/github/get-current-branch.ts
+++ b/src/github/get-current-branch.ts
@@ -1,7 +1,7 @@
 import { Effect, pipe } from 'effect';
 
 import { UnknownCurrentBranchError } from '../errors/index.js';
-import type { GithubEvent } from '../types/github.types.js';
+import type { GithubEvent } from '../types/index.js';
 
 export const getCurrentBranch = (event: GithubEvent) =>
   pipe(

--- a/src/matchers/get-error-message-from-cause.ts
+++ b/src/matchers/get-error-message-from-cause.ts
@@ -6,6 +6,7 @@ import type {
   GithubActionsExecError,
   InvalidKeywordsError,
   NoGithubEventError,
+  PackageJsonNameFetchingError,
   PackageJsonVersionFetchingError,
   UnknownCurrentBranchError,
   UnknownDefaultBranchError,
@@ -20,7 +21,8 @@ export const getErrorMessageFrom = (
     | GithubActionsExecError
     | CommitMessagesExtractionError
     | InvalidKeywordsError
-    | PackageJsonVersionFetchingError,
+    | PackageJsonVersionFetchingError
+    | PackageJsonNameFetchingError,
 ) =>
   Match.value(cause).pipe(
     Match.when(
@@ -45,7 +47,11 @@ export const getErrorMessageFrom = (
     ),
     Match.when(
       { _tag: 'package-json-version-fetching-failure' },
-      () => '❌ Failed to read package json file.',
+      () => '❌ Failed to extract version from package json file.',
+    ),
+    Match.when(
+      { _tag: 'package-json-name-fetching-failure' },
+      () => '❌ Failed to extract name package json file.',
     ),
     Match.orElse(() => '❌ Oh no! An unknown error occured.'),
   );

--- a/src/output/output.version.ts
+++ b/src/output/output.version.ts
@@ -3,12 +3,11 @@ import { Effect, pipe } from 'effect';
 
 import { PackageJsonVersionFetchingError } from '../errors/index.js';
 import { readJsonEffect } from '../fs/fs.effects.js';
+import type { PackageJson } from '../types/index.js';
 
 export const outputVersion = pipe(
   Effect.gen(function* () {
-    const packageData = yield* readJsonEffect<{ version: string }>(
-      './package.json',
-    );
+    const packageData = yield* readJsonEffect<PackageJson>('./package.json');
 
     setOutput('new-version', packageData.version);
   }),

--- a/src/semver/get-keywords.ts
+++ b/src/semver/get-keywords.ts
@@ -24,6 +24,7 @@ export const getKeywords = pipe(
       ) {
         error(`⚠️ Expecting at least one ${type} keyword but got 0.`);
       }
+
       return array;
     });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './github.types.js';
+export * from './package-json.type.js';

--- a/src/types/package-json.type.ts
+++ b/src/types/package-json.type.ts
@@ -1,0 +1,4 @@
+export type PackageJson = {
+  name: string;
+  version: string;
+};


### PR DESCRIPTION
# Inputs

New input `cwd`. 

Usage:
```yaml
- name: ⏫ Bumping version
  uses: jpb06/bump-package@latest
    with:
      cwd: ./libs/my-package
```

# Pushed tag format

 - Before: `v<version>`; example: `v1.3.2`.
 - Now: `<package_name>@v<version>`; example: `my-package@v1.3.2`

# pushed commit message format

 - Before: `<version>`; example: `1.3.2`.
 - Now: `chore(<package_name>): bump version to <version>`; example: `chore(my-package): bump version to v1.3.2`